### PR TITLE
Make all write operations "consistent" (kind of)

### DIFF
--- a/spandex-common/src/main/resources/application.conf
+++ b/spandex-common/src/main/resources/application.conf
@@ -10,6 +10,8 @@ com.socrata.spandex {
     data-copy-batch-size = 1000
     data-copy-timeout = 60s
 
+    # TODO - Move index mappings out of configuration.
+    # They should be in some kind of bootstrap/migration script instead.
     mappings {
       dataset-copy {
         mapping-type="dataset_copy"

--- a/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexElasticSearchClient.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexElasticSearchClient.scala
@@ -19,9 +19,19 @@ import org.elasticsearch.index.query.QueryBuilders._
 import org.elasticsearch.search.aggregations.AggregationBuilders._
 import org.elasticsearch.search.sort.SortOrder
 
+// scalastyle:off number.of.methods
 case class ElasticSearchResponseFailed(msg: String) extends Exception(msg)
 
-// scalastyle:off number.of.methods
+// Setting refresh to true on ES write calls, because we always want to be
+// sure that we're operating on the very latest copy. We are trading off some speed to get
+// consistency.
+// Without this, when we create a new working copy, more often than not the brand new
+// dataset_copy document isn't indexed yet, and we perform all subsequent event operations
+// on a stale copy.
+// Caveats:
+// - refresh=true only guarantees consistency on a single shard.
+// - We aren't actually sure what the perf implications of running like this at production scale are.
+// http://www.elastic.co/guide/en/elasticsearch/reference/1.x/docs-index_.html#index-refresh
 class SpandexElasticSearchClient(config: ElasticSearchConfig) extends ElasticSearchClient(config) with Logging {
   private def byDatasetIdQuery(datasetId: String): QueryBuilder = termQuery(SpandexFields.DatasetId, datasetId)
   private def byDatasetIdAndStageQuery(datasetId: String, stage: LifecycleStage): QueryBuilder =
@@ -72,6 +82,7 @@ class SpandexElasticSearchClient(config: ElasticSearchConfig) extends ElasticSea
     checkForFailures(
       client.prepareIndex(config.index, config.columnMapMapping.mappingType, columnMap.docId)
           .setSource(JsonUtil.renderJson(columnMap))
+          .setRefresh(true)
           .execute.actionGet)
 
   def getColumnMap(datasetId: String, copyNumber: Long, userColumnId: String): Option[ColumnMap] = {
@@ -142,8 +153,9 @@ class SpandexElasticSearchClient(config: ElasticSearchConfig) extends ElasticSea
   }
 
   // Yuk @ Seq[Any], but the number of types on ActionRequestBuilder is absurd.
-  def sendBulkRequest(requests: Seq[Any]): Unit =
-    checkForFailures(requests.foldLeft(client.prepareBulk()) { case (bulk, single) =>
+  def sendBulkRequest(requests: Seq[Any]): Unit = {
+    val baseRequest = client.prepareBulk().setRefresh(true)
+    checkForFailures(requests.foldLeft(baseRequest) { case (bulk, single) =>
         single match {
           case i: IndexRequestBuilder => bulk.add(i)
           case u: UpdateRequestBuilder => bulk.add(u)
@@ -152,6 +164,7 @@ class SpandexElasticSearchClient(config: ElasticSearchConfig) extends ElasticSea
               s"Bulk requests with ${a.getClass.getSimpleName} not supported")
         }
       }.execute.actionGet)
+  }
 
   def copyFieldValues(from: DatasetCopy, to: DatasetCopy): Unit = {
     val timeout = new TimeValue(config.dataCopyTimeout)
@@ -242,16 +255,6 @@ class SpandexElasticSearchClient(config: ElasticSearchConfig) extends ElasticSea
     val source = JsonUtil.renderJson(DatasetCopy(datasetId, copyNumber, dataVersion, stage))
     client.prepareIndex(config.index, config.datasetCopyMapping.mappingType, id)
           .setSource(source)
-      // IMPORTANT! Setting refresh to true on this specific ES call, because we always want to be
-      // sure that we're operating on the very latest copy. We are trading off some speed to get
-      // consistency.
-      // Without this, when we create a new working copy, more often than not the brand new
-      // dataset_copy document isn't indexed yet, and we perform all subsequent event operations
-      // on a stale copy.
-      // Refresh is still false when indexing column_maps and field_values, because we don't ever
-      // need to search for them immediately afterward. As a result, we have some Thread.sleeps
-      // in test code.
-      // http://www.elastic.co/guide/en/elasticsearch/reference/1.x/docs-index_.html#index-refresh
           .setRefresh(true)
           .execute.actionGet
   }
@@ -262,6 +265,7 @@ class SpandexElasticSearchClient(config: ElasticSearchConfig) extends ElasticSea
       client.prepareUpdate(config.index, config.datasetCopyMapping.mappingType, datasetCopy.docId)
             .setDoc(source)
             .setUpsert()
+            .setRefresh(true)
             .execute.actionGet)
   }
 

--- a/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexElasticSearchClient.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexElasticSearchClient.scala
@@ -137,10 +137,10 @@ class SpandexElasticSearchClient(config: ElasticSearchConfig) extends ElasticSea
   }
 
   def indexFieldValue(fieldValue: FieldValue): Unit =
-    checkForFailures(getIndexRequest(fieldValue).execute.actionGet)
+    checkForFailures(getIndexRequest(fieldValue).setRefresh(true).execute.actionGet)
 
   def updateFieldValue(fieldValue: FieldValue): Unit =
-    checkForFailures(getUpdateRequest(fieldValue).execute.actionGet)
+    checkForFailures(getUpdateRequest(fieldValue).setRefresh(true).execute.actionGet)
 
   def getIndexRequest(fieldValue: FieldValue) : IndexRequestBuilder =
     client.prepareIndex(config.index, config.fieldValueMapping.mappingType, fieldValue.docId)

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
@@ -169,7 +169,6 @@ class SpandexElasticSearchClientSpec extends FunSuiteLike with Matchers with Bef
     client.getDatasetCopy(datasets(0), 4) should not be 'defined
 
     client.putDatasetCopy(datasets(0), 4, 20, LifecycleStage.Unpublished)
-    Thread.sleep(1000) // Account for ES indexing delay
     client.getDatasetCopy(datasets(0), 4) should be
       (Some(DatasetCopy(datasets(0), 4, 20, LifecycleStage.Unpublished)))
 
@@ -194,7 +193,6 @@ class SpandexElasticSearchClientSpec extends FunSuiteLike with Matchers with Bef
 
   test("Update dataset copy version") {
     client.putDatasetCopy(datasets(1), 1, 2, LifecycleStage.Unpublished)
-    Thread.sleep(1000) // Account for ES indexing delay
 
     val current = client.getDatasetCopy(datasets(1), 1)
     current should be ('defined)
@@ -212,7 +210,6 @@ class SpandexElasticSearchClientSpec extends FunSuiteLike with Matchers with Bef
   test("Delete dataset copy by copy number") {
     client.putDatasetCopy(datasets(0), 1, 50L, LifecycleStage.Unpublished)
     client.putDatasetCopy(datasets(0), 2, 100L, LifecycleStage.Published)
-    Thread.sleep(1000) // Account for ES indexing delay
 
     client.getDatasetCopy(datasets(0), 1) should be ('defined)
     client.getDatasetCopy(datasets(0), 2) should be ('defined)

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
@@ -110,13 +110,11 @@ class SpandexElasticSearchClientSpec extends FunSuiteLike with Matchers with Bef
 
     val inserts = toCopy.map(client.getIndexRequest)
     client.sendBulkRequest(inserts)
-    Thread.sleep(1000) // Account for ES indexing delay
 
     client.searchFieldValuesByCopyNumber(from.datasetId, from.copyNumber).totalHits should be (100)
     client.searchFieldValuesByCopyNumber(to.datasetId, to.copyNumber).totalHits should be (0)
 
     client.copyFieldValues(from, to)
-    Thread.sleep(1000) // Account for ES indexing delay
 
     client.searchFieldValuesByCopyNumber(from.datasetId, from.copyNumber).totalHits should be (100)
     client.searchFieldValuesByCopyNumber(to.datasetId, to.copyNumber).totalHits should be (100)
@@ -128,7 +126,6 @@ class SpandexElasticSearchClientSpec extends FunSuiteLike with Matchers with Bef
 
     val colMap = ColumnMap(datasets(0), 1, 1, "col1-1111")
     client.putColumnMap(colMap)
-    Thread.sleep(1000) // Account for ES indexing delay
 
     val colMap1 = client.getColumnMap(datasets(0), 1, "col1-1111")
     colMap1 should be (Some(colMap))
@@ -200,7 +197,6 @@ class SpandexElasticSearchClientSpec extends FunSuiteLike with Matchers with Bef
     current.get.stage should be (LifecycleStage.Unpublished)
 
     client.updateDatasetCopyVersion(current.get.updateCopy(5, LifecycleStage.Published))
-    Thread.sleep(1000) // Account for ES indexing delay
 
     client.getDatasetCopy(datasets(1), 1) should be ('defined)
     client.getDatasetCopy(datasets(1), 1).get.version should be (5)
@@ -215,7 +211,6 @@ class SpandexElasticSearchClientSpec extends FunSuiteLike with Matchers with Bef
     client.getDatasetCopy(datasets(0), 2) should be ('defined)
 
     client.deleteDatasetCopy(datasets(0), 2)
-    Thread.sleep(1000) // Account for ES indexing delay
 
     client.getDatasetCopy(datasets(0), 1) should be ('defined)
     client.getDatasetCopy(datasets(0), 2) should not be ('defined)

--- a/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexServletSpec.scala
+++ b/spandex-http/src/test/scala/com/socrata/spandex/http/SpandexServletSpec.scala
@@ -3,7 +3,7 @@ package com.socrata.spandex.http
 import javax.servlet.http.{HttpServletResponse => HttpStatus}
 
 import com.socrata.spandex.common._
-import com.socrata.spandex.common.client.{ColumnMap, SpandexElasticSearchClient, TestESClient}
+import com.socrata.spandex.common.client.{SpandexElasticSearchClient, TestESClient}
 import org.eclipse.jetty.webapp.WebAppContext
 import org.scalatest.FunSuiteLike
 import org.scalatra.servlet.ScalatraListener

--- a/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/SecondaryEventLogger.scala
+++ b/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/SecondaryEventLogger.scala
@@ -9,8 +9,7 @@ trait SecondaryEventLogger extends Logging {
     logger.info(s"$eventName event: $description")
 
   def logDataVersionBump(dataset:String, copyNumber: Long, oldVersion: Long, newVersion: Long): Unit =
-    logger.info(s"Bumping data version from $oldVersion to $newVersion " +
-                s"for dataset $dataset copy $copyNumber")
+    logger.info(s"Bumping data version to $newVersion for dataset $dataset copy $copyNumber")
 
   def logWorkingCopyCreated(dataset: String, copyNumber: Long): Unit =
     logEvent("WorkingCopyCreated",

--- a/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/VersionEventsHandler.scala
+++ b/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/VersionEventsHandler.scala
@@ -26,7 +26,6 @@ class VersionEventsHandler(client: SpandexElasticSearchClient) extends Secondary
     // 2. Batch up all the index updates and send them to ES in one go. This will make a single
     //    batch of events internally consistent but if we get 2 batches in quick succession there
     //    are no guarantees.
-    Thread.sleep(1000) // scalastyle:ignore magic.number
 
     // Find the latest dataset copy number. This *should* exist since
     // we have already handled creation of any initial working copies.
@@ -77,9 +76,6 @@ class VersionEventsHandler(client: SpandexElasticSearchClient) extends Secondary
           throw new UnsupportedOperationException("Unexpected WorkingCopyCreated event")
       }
     }
-
-    // TODO : Don't do this. See notes above.
-    Thread.sleep(1000) // scalastyle:ignore magic.number
 
     // Finally, get whatever the new latest copy is and bump its data version.
     logDataVersionBump(datasetName, latest.copyNumber, latest.version, dataVersion)

--- a/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/VersionEventsHandler.scala
+++ b/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/VersionEventsHandler.scala
@@ -14,19 +14,6 @@ class VersionEventsHandler(client: SpandexElasticSearchClient) extends Secondary
     // First, handle any working copy events
     val remainingEvents = WorkingCopyCreatedHandler(client).go(datasetName, dataVersion, events)
 
-    // TODO : Decide how to deal with Elastic Search's indexing delay.
-    // ES only refreshes the index at set intervals (default 1s, configurable)
-    // instead of after every single write.
-    // http://www.elastic.co/guide/en/elasticsearch/reference/current/_modifying_your_data.html
-    // http://blog.sematext.com/2013/07/08/elasticsearch-refresh-interval-vs-indexing-performance/
-    // Things we can do instead of terrible Thread.sleeps everywhere:
-    // 1. Turn off the refresh interval and set ES to refresh the index after every write.
-    //    Pros - consistent reads.
-    //    Cons - indexing throughput is lessened, see blog post above. This may be acceptable.
-    // 2. Batch up all the index updates and send them to ES in one go. This will make a single
-    //    batch of events internally consistent but if we get 2 batches in quick succession there
-    //    are no guarantees.
-
     // Find the latest dataset copy number. This *should* exist since
     // we have already handled creation of any initial working copies.
     val latest = client.getLatestCopyForDataset(datasetName).getOrElse(

--- a/spandex-secondary/src/test/scala/com/socrata/spandex/secondary/SpandexSecondaryLikeSpec.scala
+++ b/spandex-secondary/src/test/scala/com/socrata/spandex/secondary/SpandexSecondaryLikeSpec.scala
@@ -96,7 +96,6 @@ class SpandexSecondaryLikeSpec extends FunSuiteLike with Matchers with TestESDat
     )
 
     secondary.resync(datasetInfo, copyInfo, schema, None, unmanaged(rows.iterator), Seq.empty)
-    Thread.sleep(1000) // Wait for ES to reindex
 
     val copies = client.searchCopiesByDataset("zoo-animals")
     copies.totalHits should be (1)

--- a/spandex-secondary/src/test/scala/com/socrata/spandex/secondary/VersionEventsHandlerSpec.scala
+++ b/spandex-secondary/src/test/scala/com/socrata/spandex/secondary/VersionEventsHandlerSpec.scala
@@ -25,7 +25,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
   override def beforeEach(): Unit = {
     client.deleteAllDatasetCopies()
     bootstrapData()
-    Thread.sleep(1000) // Wait for ES to index documents
   }
   override def afterEach(): Unit = removeBootstrapData()
   override def afterAll(): Unit = client.close()
@@ -51,7 +50,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
     val events = Seq(WorkingCopyCreated(copyInfo)).iterator
 
     client.putDatasetCopy(dataset, copyInfo.copyNumber, dataVersion, copyInfo.lifecycleStage)
-    Thread.sleep(1000) // Wait for ES to index document
 
     a [ResyncSecondaryException] should be thrownBy handler.handle(dataset, 1, events)
   }
@@ -150,7 +148,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
 
   test("WorkingCopyDropped - throw an exception if the copy is the initial copy") {
     client.putDatasetCopy("wcd-test-initial-copy", 1, 1, LifecycleStage.Unpublished)
-    Thread.sleep(1000) // Wait for ES to index document
 
     val expectedBefore = Some(DatasetCopy("wcd-test-initial-copy", 1, 1, LifecycleStage.Unpublished))
     client.getLatestCopyForDataset("wcd-test-initial-copy") should be(expectedBefore)
@@ -161,7 +158,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
 
   test("WorkingCopyDropped - throw an exception if the copy is in the wrong stage") {
     client.putDatasetCopy("wcd-test-published", 2, 2, LifecycleStage.Published)
-    Thread.sleep(1000) // Wait for ES to index document
 
     val expectedBefore = Some(DatasetCopy("wcd-test-published", 2, 2, LifecycleStage.Published))
     client.getLatestCopyForDataset("wcd-test-published") should be(expectedBefore)
@@ -195,7 +191,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
 
   test("SnapshotDropped - throw an exception if the copy is in the wrong stage") {
     client.putDatasetCopy("sd-test-notsnapshot", 2, 2, LifecycleStage.Unpublished)
-    Thread.sleep(1000) // Wait for ES to index document
 
     val expectedBefore = Some(DatasetCopy("sd-test-notsnapshot", 2, 2, LifecycleStage.Unpublished))
     client.getLatestCopyForDataset("sd-test-notsnapshot") should be (expectedBefore)

--- a/spandex-secondary/src/test/scala/com/socrata/spandex/secondary/VersionEventsHandlerSpec.scala
+++ b/spandex-secondary/src/test/scala/com/socrata/spandex/secondary/VersionEventsHandlerSpec.scala
@@ -78,7 +78,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
     client.searchFieldValuesByCopyNumber(datasets(0), expectedLatestBefore.copyNumber).totalHits should be (15)
 
     handler.handle(datasets(0), expectedLatestBefore.version + 1, Seq(Truncated).iterator)
-    Thread.sleep(1000) // Wait for ES to index document
 
     val latestAfter = client.getLatestCopyForDataset(datasets(0))
     latestAfter should be ('defined)
@@ -93,7 +92,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
 
     // Create column
     handler.handle(datasets(0), 3, Seq(ColumnCreated(numCol), ColumnCreated(textCol)).iterator)
-    Thread.sleep(1000) // Wait for ES to index document
 
     val latest = client.getLatestCopyForDataset(datasets(0))
     client.getColumnMap(datasets(0), latest.get.copyNumber, numCol.id.underlying) should not be 'defined
@@ -114,7 +112,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
 
     // Create column
     handler.handle(datasets(0), expectedLatestBefore.version + 1, Seq(ColumnCreated(info)).iterator)
-    Thread.sleep(1000) // Wait for ES to index document
 
     client.getColumnMap(datasets(0), expectedLatestBefore.copyNumber, info.id.underlying) should be
       (Some(ColumnMap(datasets(0), 2, info.systemId.underlying, info.id.underlying)))
@@ -124,7 +121,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
 
     // Remove column
     handler.handle(datasets(0), expectedLatestBefore.version + 1, Seq(ColumnRemoved(info)).iterator)
-    Thread.sleep(1000) // Wait for ES to index document
 
     val latestAfterDelete = client.getLatestCopyForDataset(datasets(0))
     latestAfterDelete should be ('defined)
@@ -140,7 +136,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
    client.getLatestCopyForDataset(datasets(0)) should be (Some(expectedLatestBefore))
 
    handler.handle(datasets(0), expectedLatestBefore.version + 1, Seq(WorkingCopyPublished).iterator)
-   Thread.sleep(1000) // Wait for ES to index document
 
    val expectedAfter = expectedLatestBefore.updateCopy(expectedLatestBefore.version + 1, LifecycleStage.Published)
    client.getLatestCopyForDataset(datasets(0)) should be (Some(expectedAfter))
@@ -177,7 +172,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
     client.searchColumnMapsByCopyNumber(datasets(1), 3).totalHits should be (3)
 
     handler.handle(datasets(1), expectedBefore.version + 1, Seq(WorkingCopyDropped).iterator)
-    Thread.sleep(1000) // Wait for ES to index document
 
     val expectedAfter = copies(datasets(1))(1).updateCopy(expectedBefore.version + 1)
     client.getLatestCopyForDataset(datasets(1)) should be (Some(expectedAfter))
@@ -213,7 +207,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
     val snapshot = copies(datasets(1)).head
     val copyInfo = CopyInfo(new CopyId(100), snapshot.copyNumber, snapshot.stage, snapshot.version, DateTime.now)
     handler.handle(datasets(1), expectedBefore.version + 1, Seq(SnapshotDropped(copyInfo)).iterator)
-    Thread.sleep(1000) // Wait for ES to index document
 
     val expectedAfter = expectedBefore.updateCopy(expectedBefore.version + 1)
     client.getLatestCopyForDataset(datasets(1)) should be (Some(expectedAfter))
@@ -239,7 +232,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
 
     val insertEvents = Seq(RowDataUpdated(Seq[Operation](insert))).iterator
     handler.handle(datasets(1), expectedBeforeInsert.version + 1, insertEvents)
-    Thread.sleep(1000) // Wait for ES to index document
 
     val expectedAfterInsert = expectedBeforeInsert.updateCopy(expectedBeforeInsert.version + 1)
     client.getLatestCopyForDataset(datasets(1)) should be (Some(expectedAfterInsert))
@@ -256,7 +248,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
 
     val updateEvents = Seq(RowDataUpdated(Seq[Operation](update))).iterator
     handler.handle(datasets(1), expectedAfterInsert.version + 1, updateEvents)
-    Thread.sleep(1000) // Wait for ES to index document
 
     val expectedAfter = expectedAfterInsert.updateCopy(expectedAfterInsert.version + 1)
     client.getLatestCopyForDataset(datasets(1)) should be (Some(expectedAfter))
@@ -284,7 +275,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
     val events = Seq(RowDataUpdated(
       Seq[Operation](Delete(new RowId(2))(None), Delete(new RowId(5))(None)))).iterator
     handler.handle(datasets(1), expectedBefore.version + 1, events)
-    Thread.sleep(1000) // Wait for ES to index document
 
     val expectedAfter = expectedBefore.updateCopy(expectedBefore.version + 1)
     client.getLatestCopyForDataset(datasets(1)) should be (Some(expectedAfter))
@@ -296,7 +286,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
   test("DataCopied - all field values from last published copy should be copied to latest copy") {
     // Remove bootstrapped data on working copy
     client.deleteFieldValuesByCopyNumber(datasets(1), 3)
-    Thread.sleep(1000) // Wait for ES to index document
 
     val expectedBefore = copies(datasets(1)).last
     client.getLatestCopyForDataset(datasets(1)) should be (Some(expectedBefore))
@@ -304,7 +293,6 @@ class VersionEventsHandlerSpec extends FunSuiteLike
     client.searchFieldValuesByCopyNumber(datasets(1), 3).totalHits should be (0)
 
     handler.handle(datasets(1), expectedBefore.version + 1, Seq(DataCopied).iterator)
-    Thread.sleep(1000) // Wait for ES to index document
 
     val expectedAfter = expectedBefore.updateCopy(expectedBefore.version + 1)
     client.getLatestCopyForDataset(datasets(1)) should be (Some(expectedAfter))


### PR DESCRIPTION
Setting refresh=true on all secondary write operations.
http://www.elastic.co/guide/en/elasticsearch/reference/1.x/docs-index_.html#index-refresh

We always want to be sure that we're operating on the very latest copy. We are trading off some speed to get consistency. Without this, when we create a new working copy, more often than not the brand new dataset_copy document isn't indexed yet, and we perform all subsequent event operations on a stale copy.

Caveats:
- refresh=true only guarantees consistency on a single shard.
- We aren't actually sure what the perf implications of running like this at production scale are.