### PR TITLE
Don't send empty bulk requests to ES

### DIFF
--- a/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexElasticSearchClient.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexElasticSearchClient.scala
@@ -156,8 +156,9 @@ class SpandexElasticSearchClient(config: ElasticSearchConfig) extends ElasticSea
 
   // Yuk @ Seq[Any], but the number of types on ActionRequestBuilder is absurd.
   def sendBulkRequest(requests: Seq[Any], refresh: Boolean): Unit = {
-    val baseRequest = client.prepareBulk().setRefresh(refresh)
-    checkForFailures(requests.foldLeft(baseRequest) { case (bulk, single) =>
+    if (requests.nonEmpty) {
+      val baseRequest = client.prepareBulk().setRefresh(refresh)
+      checkForFailures(requests.foldLeft(baseRequest) { case (bulk, single) =>
         single match {
           case i: IndexRequestBuilder => bulk.add(i)
           case u: UpdateRequestBuilder => bulk.add(u)
@@ -166,6 +167,7 @@ class SpandexElasticSearchClient(config: ElasticSearchConfig) extends ElasticSea
               s"Bulk requests with ${a.getClass.getSimpleName} not supported")
         }
       }.execute.actionGet)
+    }
   }
 
   def copyFieldValues(from: DatasetCopy, to: DatasetCopy, refresh: Boolean): Unit = {

--- a/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
+++ b/spandex-common/src/test/scala/com/socrata/spandex/common/client/SpandexElasticSearchClientSpec.scala
@@ -2,7 +2,7 @@ package com.socrata.spandex.common.client
 
 import com.socrata.datacoordinator.secondary.LifecycleStage
 import com.socrata.spandex.common.{SpandexConfig, TestESData}
-import org.elasticsearch.rest.RestStatus
+import org.elasticsearch.action.index.IndexRequestBuilder
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuiteLike, Matchers}
 
 // scalastyle:off
@@ -45,6 +45,12 @@ class SpandexElasticSearchClientSpec extends FunSuiteLike with Matchers with Bef
     client.getFieldValue(toInsert(0)).get should be (toUpdate(0))
     client.getFieldValue(toInsert(1)).get should be (toInsert(1))
     client.getFieldValue(toInsert(2)).get should be (toUpdate(1))
+  }
+
+  test("Don't send empty bulk requests to Elastic Search") {
+    val empty = Seq.empty[IndexRequestBuilder]
+    // BulkRequest.validate throws if given an empty bulk request
+    client.sendBulkRequest(empty, refresh = true)
   }
 
   test("Delete field values by dataset") {


### PR DESCRIPTION
Will fix some of the errors being thrown in staging right now:
```
ERROR [Worker 4 for secondary spandex] () [] SecondaryWatcher Unexpected exception while updating dataset DatasetId(15006) in secondary spandex; marking it as broken
org.elasticsearch.action.ActionRequestValidationException: Validation Failed: 1: no requests added;
	at org.elasticsearch.action.ValidateActions.addValidationError(ValidateActions.java:29)
	at org.elasticsearch.action.bulk.BulkRequest.validate(BulkRequest.java:459)
	at org.elasticsearch.action.TransportActionNodeProxy.execute(TransportActionNodeProxy.java:52)
	at org.elasticsearch.client.transport.support.InternalTransportClient$1.doWithNode(InternalTransportClient.java:109)
	at org.elasticsearch.client.transport.TransportClientNodesService.execute(TransportClientNodesService.java:202)
	at org.elasticsearch.client.transport.support.InternalTransportClient.execute(InternalTransportClient.java:106)
	at org.elasticsearch.client.support.AbstractClient.bulk(AbstractClient.java:163)
	at org.elasticsearch.client.transport.TransportClient.bulk(TransportClient.java:364)
	at org.elasticsearch.action.bulk.BulkRequestBuilder.doExecute(BulkRequestBuilder.java:164)
	at org.elasticsearch.action.ActionRequestBuilder.execute(ActionRequestBuilder.java:91)
	at org.elasticsearch.action.ActionRequestBuilder.execute(ActionRequestBuilder.java:65)
	at com.socrata.spandex.common.client.SpandexElasticSearchClient.sendBulkRequest(SpandexElasticSearchClient.scala:166)
```