### PR TITLE
Move test methods to test class

### DIFF
--- a/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexElasticSearchClient.scala
+++ b/spandex-common/src/main/scala/com/socrata/spandex/common/client/SpandexElasticSearchClient.scala
@@ -96,14 +96,6 @@ class SpandexElasticSearchClient(config: ElasticSearchConfig) extends ElasticSea
     response.result[ColumnMap]
   }
 
-  def getColumnMap(datasetId: String, copyNumber: Long, systemColumnId: Long): Option[ColumnMap] = {
-    val response = client.prepareSearch(config.index)
-      .setTypes(config.columnMapMapping.mappingType)
-      .setQuery(boolQuery().must(termQuery(SpandexFields.ColumnId, systemColumnId)))
-      .execute.actionGet
-    response.results[ColumnMap].thisPage.headOption
-  }
-
   def deleteColumnMap(datasetId: String, copyNumber: Long, userColumnId: String): Unit = {
     val id = ColumnMap.makeDocId(datasetId, copyNumber, userColumnId)
     checkForFailures(client.prepareDelete(config.index, config.columnMapMapping.mappingType, id)


### PR DESCRIPTION
Moving all search methods to a test class where they belong, so we don't accidentally use them in production code.

We can't consider these as production-grade search methods, since they only return the first page of results. The only exception to this is the search in getLatestCopyForDataset, which explicitly restricts the page size to 1.

Handily, this also greatly reduces the size of our client class so we can *almost* remove the number.of.methods Scalastyle suppression.