### PR TITLE
Log exceptions instead of swallowing them

### DIFF
--- a/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexError.scala
+++ b/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexError.scala
@@ -8,4 +8,7 @@ case class SpandexError(message: String,
 
 object SpandexError {
   implicit val jCode = AutomaticJsonCodecBuilder[SpandexError]
+
+  def apply(e: Exception): SpandexError =
+    SpandexError(s"${e.getClass.getSimpleName}: ${e.getMessage}\n${e.getStackTraceString}")
 }

--- a/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexServlet.scala
+++ b/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexServlet.scala
@@ -6,14 +6,13 @@ import com.rojoma.json.v3.ast.{JObject, JString}
 import com.rojoma.json.v3.util.JsonUtil
 import com.socrata.spandex.common._
 import com.socrata.spandex.common.client._
-import com.typesafe.scalalogging.slf4j.Logging
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.common.unit.Fuzziness
 
 import scala.util.Try
 
 class SpandexServlet(conf: SpandexConfig,
-                     client: SpandexElasticSearchClient) extends SpandexStack with Logging {
+                     client: SpandexElasticSearchClient) extends SpandexStack {
   def index: String = conf.es.index
 
   val version = JsonUtil.renderJson(JObject(BuildInfo.toMap.mapValues(v => JString(v.toString))))
@@ -87,7 +86,7 @@ class SpandexServlet(conf: SpandexConfig,
     val text = urlDecode(params.get(paramText).getOrElse(""))
     val fuzz = Fuzziness.build(params.getOrElse(paramFuzz, conf.suggestFuzziness))
     val size = params.get(paramSize).headOption.fold(conf.suggestSize)(_.toInt)
-    logger.info(s">>> $datasetId, $copyNum, $userColumnId, $text, $fuzz, $size")
+    logger.info(s">>> $datasetId, $copyNum, $userColumnId, $text, ${fuzz.asDistance}, $size")
 
     val column = columnMap(datasetId, copyNum, userColumnId)
     logger.info(s"found column $column")

--- a/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexStack.scala
+++ b/spandex-http/src/main/scala/com/socrata/spandex/http/SpandexStack.scala
@@ -2,6 +2,8 @@ package com.socrata.spandex.http
 
 import javax.servlet.http.HttpServletRequest
 
+import com.rojoma.json.v3.util.JsonUtil
+import com.typesafe.scalalogging.slf4j.Logging
 import org.fusesource.scalate.TemplateEngine
 import org.fusesource.scalate.layout.DefaultLayoutStrategy
 import org.scalatra._
@@ -9,7 +11,7 @@ import org.scalatra.scalate.ScalateSupport
 
 import scala.collection.mutable.{Map => MutableMap}
 
-trait SpandexStack extends ScalatraServlet with ScalateSupport {
+trait SpandexStack extends ScalatraServlet with ScalateSupport with Logging {
 
   /* wire up the precompiled templates */
   override protected def defaultTemplatePath: List[String] = List("/WEB-INF/templates/views")
@@ -34,5 +36,11 @@ trait SpandexStack extends ScalatraServlet with ScalateSupport {
       contentType = "text/html"
       layoutTemplate(path)
     } orElse serveStaticResource() getOrElse resourceNotFound()
+  }
+
+  error {
+    case e: Exception =>
+      logger.error("Exception was thrown", e)
+      InternalServerError(JsonUtil.renderJson(SpandexError(e)))
   }
 }


### PR DESCRIPTION
Currently if an exception is thrown we return it in the client response but don't log it.