### PR TITLE
Ensure we refresh when calling publish for the first time

### DIFF
--- a/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/PublishHandler.scala
+++ b/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/PublishHandler.scala
@@ -17,12 +17,14 @@ case class PublishHandler(client: SpandexElasticSearchClient) extends SecondaryE
 
     // Set the latest unpublished version to published
     client.updateDatasetCopyVersion(
-      latest.copy(stage = LifecycleStage.Published), refresh = true)
+      latest.copy(stage = LifecycleStage.Published), refresh = false)
 
     // Set the previous published version (if any) to Snapshotted
     maybeLastPublished.foreach { lastPublished =>
       client.updateDatasetCopyVersion(
-        lastPublished.copy(stage = LifecycleStage.Snapshotted), refresh = true)
+        lastPublished.copy(stage = LifecycleStage.Snapshotted), refresh = false)
     }
+
+    client.refresh()
   }
 }

--- a/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/PublishHandler.scala
+++ b/spandex-secondary/src/main/scala/com.socrata.spandex.secondary/PublishHandler.scala
@@ -17,7 +17,7 @@ case class PublishHandler(client: SpandexElasticSearchClient) extends SecondaryE
 
     // Set the latest unpublished version to published
     client.updateDatasetCopyVersion(
-      latest.copy(stage = LifecycleStage.Published), refresh = false)
+      latest.copy(stage = LifecycleStage.Published), refresh = true)
 
     // Set the previous published version (if any) to Snapshotted
     maybeLastPublished.foreach { lastPublished =>


### PR DESCRIPTION
I noticed on my local machine that if I publish a dataset for the first time, the latest dataset_copy document does not get updated to Published in the index in a timely manner. It only seems to happen when I run the actual secondary - I can't repro it via the corresponding test ("WorkingCopyPublished - publish first working copy" in `VersionEventsHandlerSpec`), and it doesn't happen if there is a previous snapshot copy, because refresh is explicitly called again in that case. Updated the code to explicitly call refresh whether there is a previous snapshot or not.

We should try to get this in ASAP, as it causes spandex replication to break on a dataset as soon as a working copy is created.